### PR TITLE
Use jq to re-format genesis file prior to preprocessing

### DIFF
--- a/cosmos_genesis_tinker.py
+++ b/cosmos_genesis_tinker.py
@@ -336,9 +336,8 @@ class GenesisTinker:  # pylint: disable=R0902,R0904
         self.log_step("Creating preprocessing file " +
                       self.preprocessing_file)
         self._preprocessing = True
-        subprocess.run([
-                'jq', "'.'", self.input_file, '>', self.preprocessing_file],
-                check=True)
+        subprocess.run(f"jq '.' {self.input_file} > {self.preprocessing_file}",
+                check=True, shell=True)
         # shutil.copy2(self.input_file, self.preprocessing_file)
 
     def replace_delegator(self, old_delegator: Delegator, new_delegator: Delegator):

--- a/cosmos_genesis_tinker.py
+++ b/cosmos_genesis_tinker.py
@@ -336,7 +336,10 @@ class GenesisTinker:  # pylint: disable=R0902,R0904
         self.log_step("Creating preprocessing file " +
                       self.preprocessing_file)
         self._preprocessing = True
-        shutil.copy2(self.input_file, self.preprocessing_file)
+        subprocess.run([
+                'jq', "'.'", self.input_file, '>', self.preprocessing_file],
+                check=True)
+        # shutil.copy2(self.input_file, self.preprocessing_file)
 
     def replace_delegator(self, old_delegator: Delegator, new_delegator: Delegator):
         """


### PR DESCRIPTION
Running `sed` directly on an exported genesis file from mainnet has started failing because it comes in as a single-line file. Running jq prior to sed should fix the issue.